### PR TITLE
enable create namespace

### DIFF
--- a/pkg/service-hub/apiserver/apiserver_test.go
+++ b/pkg/service-hub/apiserver/apiserver_test.go
@@ -161,7 +161,7 @@ func newTestDriver() *testDriver {
 		Client:                k8sClient,
 		ClusterStore:          clusterStore,
 		ClusterExpireDuration: 5 * time.Second,
-		GlobalServiceManager:  types.NewGlobalServiceManager(k8sClient),
+		GlobalServiceManager:  types.NewGlobalServiceManager(k8sClient, true),
 	})
 	Expect(err).Should(Succeed())
 

--- a/pkg/service-hub/exporter/service_exporter_test.go
+++ b/pkg/service-hub/exporter/service_exporter_test.go
@@ -300,35 +300,11 @@ func (td *testDriver) revokeGlobalService(clusterName, namespace, name string) e
 	return nil
 }
 
-func (td *testDriver) cleanServices() {
-	var serviceList corev1.ServiceList
-	Expect(k8sClient.List(context.TODO(), &serviceList)).To(Succeed())
-	for _, svc := range serviceList.Items {
-		Expect(k8sClient.Delete(context.Background(), &svc)).To(Succeed())
-	}
-}
-
-func (td *testDriver) cleanGlobalServices() {
-	var serviceList apis.GlobalServiceList
-	Expect(k8sClient.List(context.TODO(), &serviceList)).To(Succeed())
-	for _, svc := range serviceList.Items {
-		Expect(k8sClient.Delete(context.Background(), &svc)).To(Succeed())
-	}
-}
-
-func (td *testDriver) cleanEndpointSlices() {
-	var endpointSlices discoveryv1.EndpointSliceList
-	Expect(k8sClient.List(context.TODO(), &endpointSlices)).To(Succeed())
-	for _, es := range endpointSlices.Items {
-		Expect(k8sClient.Delete(context.Background(), &es)).To(Succeed())
-	}
-}
-
 func (td *testDriver) teardown() {
 	td.stopManager()
-	td.cleanServices()
-	td.cleanGlobalServices()
-	td.cleanEndpointSlices()
+	testutil.PurgeAllGlobalServices(k8sClient)
+	testutil.PurgeAllServices(k8sClient)
+	testutil.PurgeAllEndpointSlices(k8sClient)
 }
 
 func (td *testDriver) expectExporterReconcile(obj client.Object) {

--- a/pkg/service-hub/importer/global_service_importer_test.go
+++ b/pkg/service-hub/importer/global_service_importer_test.go
@@ -15,117 +15,137 @@ import (
 
 	apis "github.com/FabEdge/fab-dns/pkg/apis/v1alpha1"
 	"github.com/FabEdge/fab-dns/pkg/constants"
+	testutil "github.com/FabEdge/fab-dns/pkg/util/test"
 )
 
 var _ = Describe("GlobalServiceImporter", func() {
-	Describe("can import services returned by GetGlobalServices passed in", func() {
-		var (
-			importer       *globalServiceImporter
-			sourceServices *globalServices
-		)
+	var (
+		importer             *globalServiceImporter
+		sourceServices       *globalServices
+		allowCreateNameSpace = true
+		workNamespace        = "default"
+		getNamespace         = testutil.GenerateGetNameFunc("not-exist")
+	)
 
-		BeforeEach(func() {
-			sourceServices = &globalServices{}
-			importer = &globalServiceImporter{
-				Config: Config{
-					Interval:          time.Second,
-					GetGlobalServices: sourceServices.GetServices,
-				},
-				client: k8sClient,
-				log:    ctrlpkg.Log,
-			}
-		})
+	JustBeforeEach(func() {
+		sourceServices = &globalServices{}
+		importer = &globalServiceImporter{
+			Config: Config{
+				Interval:             time.Second,
+				GetGlobalServices:    sourceServices.GetServices,
+				AllowCreateNamespace: allowCreateNameSpace,
+			},
+			client: k8sClient,
+			log:    ctrlpkg.Log,
+		}
+	})
 
+	JustAfterEach(func() {
+		testutil.PurgeAllGlobalServices(k8sClient)
+	})
+
+	Describe("importServices", func() {
 		When("a local counterpart does not exist", func() {
 			var (
-				importedService apis.GlobalService
-				serviceKey      client.ObjectKey
+				serviceToImport, serviceToDelete       apis.GlobalService
+				serviceKeyToImport, serviceKeyToDelete client.ObjectKey
 			)
 
-			BeforeEach(func() {
-				importedService = apis.GlobalService{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:            "nginx",
-						Namespace:       "default",
-						ResourceVersion: "123456",
-					},
-					Spec: apis.GlobalServiceSpec{
-						Type: apis.ClusterIP,
-						Ports: []apis.ServicePort{
-							{
-								Name:     "web",
-								Port:     80,
-								Protocol: corev1.ProtocolTCP,
-							},
-						},
-						Endpoints: []apis.Endpoint{
-							{
-								Cluster:   "fabedge",
-								Zone:      "haidian",
-								Region:    "beijing",
-								Addresses: []string{"192.168.1.1"},
-							},
-						},
-					},
-				}
-				serviceKey = keyFromObject(&importedService)
+			JustBeforeEach(func() {
+				serviceToImport, serviceKeyToImport = makeupGlobalServiceNginx(workNamespace)
+				sourceServices.AddService(serviceToImport)
 
-				sourceServices.AddService(importedService)
+				serviceToDelete, serviceKeyToDelete = makeupGlobalService("to-delete", workNamespace)
+				importer.createOrUpdateGlobalService(serviceToDelete)
+
 				importer.importServices()
 			})
 
-			It("will create this global service under the same namespace", func() {
+			It("will save global services", func() {
 				var localService apis.GlobalService
-
 				Eventually(func() error {
-					return k8sClient.Get(context.Background(), serviceKey, &localService)
+					return k8sClient.Get(context.Background(), serviceKeyToImport, &localService)
 				}).Should(Succeed())
-				Expect(localService.Labels).To(HaveKeyWithValue(constants.KeyOriginResourceVersion, importedService.ResourceVersion))
-				Expect(localService.Spec).To(Equal(importedService.Spec))
+				expectGlobalServiceSaved(serviceToImport)
 			})
 
-			When("imported service is different from local counterpart", func() {
-				BeforeEach(func() {
-					importedService.ResourceVersion = "1234567"
-					importedService.Spec.Ports = []apis.ServicePort{
-						{
-							Name:     "web",
-							Port:     80,
-							Protocol: corev1.ProtocolTCP,
-						},
-						{
-							Name:     "health",
-							Port:     8080,
-							Protocol: corev1.ProtocolTCP,
-						},
-					}
-					sourceServices.AddService(importedService)
-					importer.importServices()
-				})
+			It("will delete global services not imported anymore", func() {
+				Eventually(func() bool {
+					err := k8sClient.Get(context.Background(), serviceKeyToDelete, &apis.GlobalService{})
+					return errors.IsNotFound(err)
+				}).Should(BeTrue(), "should get a not found error")
+			})
+		})
+	})
 
-				It("will update the local counterpart", func() {
-					var localService apis.GlobalService
+	Describe("createOrUpdateGlobalService", func() {
+		var (
+			globalService apis.GlobalService
+			serviceKey    client.ObjectKey
+		)
 
-					Eventually(func() []apis.ServicePort {
-						_ = k8sClient.Get(context.Background(), serviceKey, &localService)
-						return localService.Spec.Ports
-					}).Should(Equal(importedService.Spec.Ports))
+		BeforeEach(func() {
+			workNamespace = getNamespace()
+		})
+
+		AfterEach(func() {
+			workNamespace = "default"
+		})
+
+		Context("when are allowed to create namespace", func() {
+			JustBeforeEach(func() {
+				globalService, serviceKey = makeupGlobalServiceNginx(workNamespace)
+				importer.createOrUpdateGlobalService(globalService)
+			})
+
+			It("will create namespace if it does not exist", func() {
+				key := client.ObjectKey{Name: workNamespace}
+				Expect(k8sClient.Get(context.Background(), key, &corev1.Namespace{})).To(Succeed())
+			})
+
+			It("create global service", func() {
+				expectGlobalServiceSaved(globalService)
+			})
+
+			It("can update the global service", func() {
+				changeServicePorts(&globalService)
+				importer.createOrUpdateGlobalService(globalService)
+				expectGlobalServiceSaved(globalService)
+			})
+		})
+
+		Context("when are not allowed to create namespace", func() {
+			BeforeEach(func() {
+				allowCreateNameSpace = false
+			})
+
+			AfterEach(func() {
+				allowCreateNameSpace = true
+			})
+
+			It("won't create namespace", func() {
+				globalService, serviceKey = makeupGlobalServiceNginx(getNamespace())
+				importer.createOrUpdateGlobalService(globalService)
+
+				key := client.ObjectKey{Name: workNamespace}
+				err := k8sClient.Get(context.Background(), key, &corev1.Namespace{})
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+			})
+
+			When("namespace exists", func() {
+				It("save global service", func() {
+					globalService, serviceKey = makeupGlobalServiceNginx("default")
+					importer.createOrUpdateGlobalService(globalService)
+					expectGlobalServiceSaved(globalService)
 				})
 			})
 
-			When("a previous imported global service is gone", func() {
-				BeforeEach(func() {
-					sourceServices.Remove(importedService)
-					importer.importServices()
-				})
-
-				It("will delete its local counterpart", func() {
-					var localService apis.GlobalService
-
-					Eventually(func() bool {
-						err := k8sClient.Get(context.Background(), serviceKey, &localService)
-						return errors.IsNotFound(err)
-					}).Should(BeTrue(), "should get a not found error")
+			When("namespace does not exist", func() {
+				It("won't save global service", func() {
+					globalService, serviceKey = makeupGlobalServiceNginx(getNamespace())
+					importer.createOrUpdateGlobalService(globalService)
+					err := k8sClient.Get(context.Background(), serviceKey, &apis.GlobalService{})
+					Expect(errors.IsNotFound(err))
 				})
 			})
 		})
@@ -176,4 +196,67 @@ func (gss *globalServices) GetServices() ([]apis.GlobalService, error) {
 	}
 
 	return services, nil
+}
+
+func makeupGlobalServiceNginx(namespace string) (apis.GlobalService, client.ObjectKey) {
+	return makeupGlobalService("nginx", namespace)
+}
+
+func makeupGlobalService(name, namespace string) (apis.GlobalService, client.ObjectKey) {
+	gs := apis.GlobalService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			ResourceVersion: "123456",
+		},
+		Spec: apis.GlobalServiceSpec{
+			Type: apis.ClusterIP,
+			Ports: []apis.ServicePort{
+				{
+					Name:     "web",
+					Port:     80,
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+			Endpoints: []apis.Endpoint{
+				{
+					Cluster:   "fabedge",
+					Zone:      "haidian",
+					Region:    "beijing",
+					Addresses: []string{"192.168.1.1"},
+				},
+			},
+		},
+	}
+
+	return gs, keyFromObject(&gs)
+}
+
+func changeServicePorts(svc *apis.GlobalService) {
+	svc.ResourceVersion = "1234567"
+	svc.Spec.Ports = []apis.ServicePort{
+		{
+			Name:     "web",
+			Port:     80,
+			Protocol: corev1.ProtocolTCP,
+		},
+		{
+			Name:     "health",
+			Port:     8080,
+			Protocol: corev1.ProtocolTCP,
+		},
+	}
+}
+
+func expectGlobalServiceSaved(expectedService apis.GlobalService) {
+	var (
+		savedService apis.GlobalService
+		key          = client.ObjectKey{
+			Name:      expectedService.Name,
+			Namespace: expectedService.Namespace,
+		}
+	)
+	Expect(k8sClient.Get(context.Background(), key, &savedService)).To(Succeed())
+	Expect(savedService.Labels).To(HaveKeyWithValue(constants.KeyOriginResourceVersion, expectedService.ResourceVersion))
+	Expect(savedService.Spec).To(Equal(expectedService.Spec))
 }

--- a/pkg/service-hub/options.go
+++ b/pkg/service-hub/options.go
@@ -234,9 +234,10 @@ func (opts Options) initManagerRunnables() (err error) {
 		}
 	} else {
 		err = importer.AddToManager(importer.Config{
-			Interval:          opts.ServiceImportInterval,
-			Manager:           opts.Manager,
-			GetGlobalServices: opts.Client.DownloadAllGlobalServices,
+			Interval:             opts.ServiceImportInterval,
+			Manager:              opts.Manager,
+			GetGlobalServices:    opts.Client.DownloadAllGlobalServices,
+			AllowCreateNamespace: opts.AllowCreateNamespace,
 		})
 		if err != nil {
 			log.Error(err, "failed to add service importer")

--- a/pkg/service-hub/options.go
+++ b/pkg/service-hub/options.go
@@ -55,6 +55,7 @@ type Options struct {
 
 	ClusterExpireTime     time.Duration
 	ServiceImportInterval time.Duration
+	AllowCreateNamespace  bool
 
 	Manager      ctrlpkg.Manager
 	ClusterStore *types.ClusterStore
@@ -76,8 +77,10 @@ func (opts *Options) AddFlags(flag *pflag.FlagSet) {
 	flag.StringVar(&opts.TLSKeyFile, "tls-key-file", "", "The key file for API server/client")
 	flag.StringVar(&opts.TLSCertFile, "tls-cert-file", "", "The cert file for API server/client")
 	flag.StringVar(&opts.TLSCACertFile, "tls-ca-cert-file", "", "The CA cert file for API server/client")
+
 	flag.DurationVar(&opts.ClusterExpireTime, "cluster-expire-duration", 5*time.Minute, "Expiration time after cluster stops heartbeat")
 	flag.DurationVar(&opts.ServiceImportInterval, "service-import-interval", time.Minute, "The interval between each services importing routine")
+	flag.BoolVar(&opts.AllowCreateNamespace, "allow-create-namespace", true, "Determine if service-hub are allowed to create namespace if needed")
 }
 
 func (opts Options) Validate() error {
@@ -145,7 +148,7 @@ func (opts *Options) initManager() (err error) {
 }
 
 func (opts *Options) initAPIServer() (err error) {
-	globalServiceManager := types.NewGlobalServiceManager(opts.Manager.GetClient())
+	globalServiceManager := types.NewGlobalServiceManager(opts.Manager.GetClient(), opts.AllowCreateNamespace)
 	opts.ExportGlobalService = globalServiceManager.CreateOrMergeGlobalService
 	opts.RevokeGlobalService = globalServiceManager.RevokeGlobalService
 

--- a/pkg/service-hub/types/global_service_manager_test.go
+++ b/pkg/service-hub/types/global_service_manager_test.go
@@ -12,98 +12,162 @@ import (
 
 	apis "github.com/FabEdge/fab-dns/pkg/apis/v1alpha1"
 	"github.com/FabEdge/fab-dns/pkg/service-hub/types"
+	nsutil "github.com/FabEdge/fab-dns/pkg/util/namespace"
+	testutil "github.com/FabEdge/fab-dns/pkg/util/test"
 )
 
 var _ = Describe("GlobalServiceManager", func() {
 	var (
-		td                  *testDriver
-		serviceFromBeijing  apis.GlobalService
-		serviceFromShanghai apis.GlobalService
+		td                   *testDriver
+		serviceFromBeijing   apis.GlobalService
+		serviceFromShanghai  apis.GlobalService
+		allowCreateNamespace = true
+		workNamespace        = "default"
+		getNamespace         = testutil.GenerateGetNameFunc("not-exist")
 	)
 
-	BeforeEach(func() {
-		td = newTestDriver()
+	JustBeforeEach(func() {
+		td = newTestDriver(allowCreateNamespace, workNamespace)
 		serviceFromBeijing = td.serviceFromBeijing
 		serviceFromShanghai = td.serviceFromShanghai
 	})
 
-	AfterEach(func() {
+	JustAfterEach(func() {
 		td.clearServices()
+		allowCreateNamespace = true
+		workNamespace = "default"
 	})
 
-	When("CreateOrMergeGlobalService is called", func() {
-		Context("the corresponding global service does not exist", func() {
-			It("will create a corresponding global service under the same namespace", func() {
-				td.createOrMergeGlobalService(td.serviceFromBeijing)
-				service := td.getService()
-				Expect(service.Spec.Type).To(Equal(serviceFromBeijing.Spec.Type))
-				Expect(service.Spec.Ports).To(Equal(serviceFromBeijing.Spec.Ports))
-				Expect(service.Spec.Endpoints).To(Equal(serviceFromBeijing.Spec.Endpoints))
+	Describe("CreateOrMergeGlobalService", func() {
+		Context("manager are allowed to create namespace", func() {
+			When("namespace exists", func() {
+				Context("the corresponding global service does not exist", func() {
+					It("will create a corresponding global service under the same namespace", func() {
+						td.createOrMergeGlobalService(td.serviceFromBeijing)
+						service := td.getService()
+						Expect(service.Spec.Type).To(Equal(serviceFromBeijing.Spec.Type))
+						Expect(service.Spec.Ports).To(Equal(serviceFromBeijing.Spec.Ports))
+						Expect(service.Spec.Endpoints).To(Equal(serviceFromBeijing.Spec.Endpoints))
+					})
+				})
+
+				Context("the corresponding global service exists", func() {
+					JustBeforeEach(func() {
+						td.createOrMergeGlobalService(td.serviceFromBeijing)
+						td.createOrMergeGlobalService(td.serviceFromShanghai)
+					})
+
+					It("will update ports from request", func() {
+						service := td.getService()
+						Expect(service.Spec.Ports).To(Equal(serviceFromShanghai.Spec.Ports))
+						Expect(service.Spec.Ports).NotTo(Equal(serviceFromBeijing.Spec.Ports))
+					})
+
+					It("will append endpoints from request", func() {
+						service := td.getService()
+						Expect(service.Spec.Endpoints).To(ConsistOf(
+							serviceFromBeijing.Spec.Endpoints[0],
+							serviceFromShanghai.Spec.Endpoints[0],
+						))
+					})
+
+					When("endpoints of the new service are different from old endpoints", func() {
+						It("will remove old endpoints and append new endpoints", func() {
+							serviceFromShanghai.Spec.Endpoints = []apis.Endpoint{
+								{
+									Cluster:   "shanghai",
+									Region:    "south",
+									Zone:      "shanghai",
+									Addresses: []string{"192.168.1.3"},
+									TargetRef: &corev1.ObjectReference{
+										Kind:      "Service",
+										Name:      td.serviceName,
+										Namespace: td.namespace,
+									},
+								},
+								{
+									Cluster:   "shanghai",
+									Region:    "south",
+									Zone:      "shanghai",
+									Addresses: []string{"192.168.1.4"},
+									TargetRef: &corev1.ObjectReference{
+										Kind:      "Service",
+										Name:      td.serviceName,
+										Namespace: td.namespace,
+									},
+								},
+							}
+							td.createOrMergeGlobalService(serviceFromShanghai)
+
+							service := td.getService()
+							Expect(service.Spec.Ports).To(Equal(serviceFromShanghai.Spec.Ports))
+							Expect(service.Spec.Endpoints).To(ConsistOf(
+								serviceFromBeijing.Spec.Endpoints[0],
+								serviceFromShanghai.Spec.Endpoints[0],
+								serviceFromShanghai.Spec.Endpoints[1],
+							))
+						})
+					})
+				})
+			})
+
+			When("namespace does not exist", func() {
+				BeforeEach(func() {
+					workNamespace = getNamespace()
+				})
+
+				JustBeforeEach(func() {
+					td.createOrMergeGlobalService(serviceFromBeijing)
+				})
+
+				JustAfterEach(func() {
+					td.deleteNamespace(workNamespace)
+				})
+
+				It("will create the namespace to which global service belongs", func() {
+					td.expectNamespaceExists(workNamespace)
+				})
+
+				It("will create a corresponding global service", func() {
+					_ = td.getService()
+				})
 			})
 		})
 
-		Context("the corresponding global service exists", func() {
+		Context("manager are not to create namespace", func() {
 			BeforeEach(func() {
-				td.createOrMergeGlobalService(td.serviceFromBeijing)
-				td.createOrMergeGlobalService(td.serviceFromShanghai)
+				allowCreateNamespace = false
 			})
 
-			It("will update ports from request", func() {
-				service := td.getService()
-				Expect(service.Spec.Ports).To(Equal(serviceFromShanghai.Spec.Ports))
-				Expect(service.Spec.Ports).NotTo(Equal(serviceFromBeijing.Spec.Ports))
+			Context("namespace does not exist", func() {
+				BeforeEach(func() {
+					workNamespace = getNamespace()
+				})
+
+				JustBeforeEach(func() {
+					Expect(td.manager.CreateOrMergeGlobalService(serviceFromBeijing)).To(HaveOccurred())
+				})
+
+				It("global service will not be created", func() {
+					td.expectServiceNotFound()
+				})
+
+				It("namespace will not be created", func() {
+					td.expectNamespaceNotExists(workNamespace)
+				})
 			})
 
-			It("will append endpoints from request", func() {
-				service := td.getService()
-				Expect(service.Spec.Endpoints).To(ConsistOf(
-					serviceFromBeijing.Spec.Endpoints[0],
-					serviceFromShanghai.Spec.Endpoints[0],
-				))
-			})
-
-			When("endpoints of the new service are different from old endpoints", func() {
-				It("will remove old endpoints and append new endpoints", func() {
-					serviceFromShanghai.Spec.Endpoints = []apis.Endpoint{
-						{
-							Cluster:   "shanghai",
-							Region:    "south",
-							Zone:      "shanghai",
-							Addresses: []string{"192.168.1.3"},
-							TargetRef: &corev1.ObjectReference{
-								Kind:      "Service",
-								Name:      td.serviceName,
-								Namespace: td.namespace,
-							},
-						},
-						{
-							Cluster:   "shanghai",
-							Region:    "south",
-							Zone:      "shanghai",
-							Addresses: []string{"192.168.1.4"},
-							TargetRef: &corev1.ObjectReference{
-								Kind:      "Service",
-								Name:      td.serviceName,
-								Namespace: td.namespace,
-							},
-						},
-					}
-					td.createOrMergeGlobalService(serviceFromShanghai)
-
-					service := td.getService()
-					Expect(service.Spec.Ports).To(Equal(serviceFromShanghai.Spec.Ports))
-					Expect(service.Spec.Endpoints).To(ConsistOf(
-						serviceFromBeijing.Spec.Endpoints[0],
-						serviceFromShanghai.Spec.Endpoints[0],
-						serviceFromShanghai.Spec.Endpoints[1],
-					))
+			Context("namespace exists", func() {
+				It("global service will be created", func() {
+					td.createOrMergeGlobalService(td.serviceFromBeijing)
+					_ = td.getService()
 				})
 			})
 		})
 	})
 
-	When("RevokeGlobalService is called", func() {
-		BeforeEach(func() {
+	Describe("RevokeGlobalService", func() {
+		JustBeforeEach(func() {
 			td.createOrMergeGlobalService(serviceFromBeijing)
 			td.createOrMergeGlobalService(serviceFromShanghai)
 			td.revokeGlobalService(serviceFromBeijing)
@@ -117,7 +181,7 @@ var _ = Describe("GlobalServiceManager", func() {
 
 		It("the global service will be deleted if no endpoints are left", func() {
 			td.revokeGlobalService(serviceFromShanghai)
-			td.ExpectServiceNotFound()
+			td.expectServiceNotFound()
 		})
 
 		It("will just return without error if target global service not found", func() {
@@ -141,8 +205,8 @@ type testDriver struct {
 	namespace   string
 }
 
-func newTestDriver() *testDriver {
-	serviceName, namespace := "nginx", "default"
+func newTestDriver(allowCreateNamespace bool, namespace string) *testDriver {
+	serviceName := "nginx"
 
 	serviceFromBeijing := apis.GlobalService{
 		ObjectMeta: metav1.ObjectMeta{
@@ -209,7 +273,7 @@ func newTestDriver() *testDriver {
 	return &testDriver{
 		serviceName:         serviceName,
 		namespace:           namespace,
-		manager:             types.NewGlobalServiceManager(k8sClient),
+		manager:             types.NewGlobalServiceManager(k8sClient, allowCreateNamespace),
 		serviceFromBeijing:  serviceFromBeijing,
 		serviceFromShanghai: serviceFromShanghai,
 	}
@@ -232,7 +296,7 @@ func (td *testDriver) getService() apis.GlobalService {
 	return svc
 }
 
-func (td *testDriver) ExpectServiceNotFound() {
+func (td *testDriver) expectServiceNotFound() {
 	var svc apis.GlobalService
 
 	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: td.serviceName, Namespace: td.namespace}, &svc)
@@ -266,4 +330,16 @@ func (td *testDriver) deleteNamespace(name string) {
 	}
 
 	Expect(k8sClient.Delete(context.Background(), &ns)).To(Succeed())
+}
+
+func (td *testDriver) expectNamespaceExists(name string) {
+	exists, err := nsutil.Exists(context.Background(), k8sClient, name)
+	Expect(err).To(Succeed())
+	Expect(exists).To(BeTrue())
+}
+
+func (td *testDriver) expectNamespaceNotExists(name string) {
+	exists, err := nsutil.Exists(context.Background(), k8sClient, name)
+	Expect(err).To(Succeed())
+	Expect(exists).To(BeFalse())
 }

--- a/pkg/util/namespace/namespace.go
+++ b/pkg/util/namespace/namespace.go
@@ -1,0 +1,48 @@
+package namespace
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/FabEdge/fab-dns/pkg/constants"
+)
+
+func Ensure(ctx context.Context, cli client.Client, name string) error {
+	exists, err := Exists(ctx, cli, name)
+	if err != nil {
+		return err
+	} else if exists {
+		return nil
+	}
+
+	err = cli.Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				constants.KeyCreatedBy: constants.AppServiceHub,
+			},
+		},
+	})
+	if errors.IsAlreadyExists(err) {
+		err = nil
+	}
+
+	return err
+}
+
+func Exists(ctx context.Context, cli client.Client, name string) (bool, error) {
+	err := cli.Get(ctx, client.ObjectKey{Name: name}, &corev1.Namespace{})
+	if err == nil {
+		return true, nil
+	}
+
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+
+	return false, err
+}

--- a/pkg/util/namespace/namespace_suite_test.go
+++ b/pkg/util/namespace/namespace_suite_test.go
@@ -1,0 +1,46 @@
+package namespace_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	apis "github.com/FabEdge/fab-dns/pkg/apis/v1alpha1"
+	testutil "github.com/FabEdge/fab-dns/pkg/util/test"
+)
+
+var kubeConfig *rest.Config
+var k8sClient client.Client
+var testEnv *envtest.Environment
+
+var _ = BeforeSuite(func(done Done) {
+	testutil.SetupLogger()
+
+	By("starting test environment")
+	var err error
+	testEnv, kubeConfig, k8sClient, err = testutil.StartTestEnvWithCRD(
+		[]string{filepath.Join("..", "..", "deploy", "crd")},
+	)
+	Expect(err).ToNot(HaveOccurred())
+
+	_ = apis.AddToScheme(scheme.Scheme)
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ShouldNot(HaveOccurred())
+})
+
+func TestNamespace(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Namespace Suite")
+}

--- a/pkg/util/namespace/namespace_test.go
+++ b/pkg/util/namespace/namespace_test.go
@@ -1,0 +1,41 @@
+package namespace_test
+
+import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nsutil "github.com/FabEdge/fab-dns/pkg/util/namespace"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Namespace", func() {
+	Describe("Ensure", func() {
+		It("create a namespace if it doesn't exist", func() {
+			namespace := "test"
+			Expect(nsutil.Ensure(context.Background(), k8sClient, namespace)).To(Succeed())
+			expectNamespaceExists(namespace)
+
+			err := k8sClient.Delete(context.Background(), &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+				},
+			})
+			Expect(err).To(BeNil())
+		})
+
+		It("won't return error if namespace exists", func() {
+			namespace := "default"
+			expectNamespaceExists(namespace)
+
+			Expect(nsutil.Ensure(context.Background(), k8sClient, namespace)).To(Succeed())
+		})
+	})
+})
+
+func expectNamespaceExists(name string) {
+	exists, err := nsutil.Exists(context.Background(), k8sClient, name)
+	Expect(err).To(BeNil())
+	Expect(exists).To(BeTrue())
+}

--- a/pkg/util/test/expect.go
+++ b/pkg/util/test/expect.go
@@ -1,0 +1,38 @@
+package test
+
+import (
+	"context"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	apis "github.com/FabEdge/fab-dns/pkg/apis/v1alpha1"
+	nsutil "github.com/FabEdge/fab-dns/pkg/util/namespace"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ExpectNamespaceExists(cli client.Client, name string) {
+	exists, err := nsutil.Exists(context.Background(), cli, name)
+	Expect(err).To(Succeed())
+	Expect(exists).To(BeTrue())
+}
+
+func ExpectNamespaceNotExists(cli client.Client, name string) {
+	exists, err := nsutil.Exists(context.Background(), cli, name)
+	Expect(err).To(Succeed())
+	Expect(exists).To(BeFalse())
+}
+
+func ExpectGlobalServiceNotFound(cli client.Client, key client.ObjectKey) {
+	err := cli.Get(context.Background(), key, &apis.GlobalService{})
+	Expect(errors.IsNotFound(err)).To(BeTrue())
+}
+
+func ExpectGetGlobalService(cli client.Client, key client.ObjectKey) apis.GlobalService {
+	var svc apis.GlobalService
+
+	err := cli.Get(context.Background(), key, &svc)
+	Expect(err).To(Succeed())
+
+	return svc
+}

--- a/pkg/util/test/purge.go
+++ b/pkg/util/test/purge.go
@@ -17,70 +17,27 @@ package test
 import (
 	"context"
 
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apis "github.com/FabEdge/fab-dns/pkg/apis/v1alpha1"
 )
 
-func PurgeAllSecrets(cli client.Client, opts ...client.ListOption) error {
-	var secrets corev1.SecretList
-	err := cli.List(context.TODO(), &secrets)
-	if err != nil {
-		return err
-	}
+func PurgeAllGlobalServices(cli client.Client, opts ...client.ListOption) {
+	var gss apis.GlobalServiceList
+	Expect(cli.List(context.TODO(), &gss)).To(Succeed())
 
-	for _, secret := range secrets.Items {
-		if err := cli.Delete(context.TODO(), &secret); err != nil {
-			return err
-		}
+	for _, gs := range gss.Items {
+		Expect(cli.Delete(context.TODO(), &gs)).To(Succeed())
 	}
-
-	return nil
 }
 
-func PurgeAllConfigMaps(cli client.Client, opts ...client.ListOption) error {
-	var configs corev1.ConfigMapList
-	err := cli.List(context.TODO(), &configs)
-	if err != nil {
-		return err
+func PurgeAllServices(cli client.Client, opts ...client.ListOption) {
+	var services corev1.ServiceList
+	Expect(cli.List(context.TODO(), &services)).To(Succeed())
+
+	for _, obj := range services.Items {
+		Expect(cli.Delete(context.TODO(), &obj)).To(Succeed())
 	}
-
-	for _, secret := range configs.Items {
-		if err := cli.Delete(context.TODO(), &secret); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func PurgeAllPods(cli client.Client, opts ...client.ListOption) error {
-	var pods corev1.PodList
-	err := cli.List(context.TODO(), &pods)
-	if err != nil {
-		return err
-	}
-
-	for _, secret := range pods.Items {
-		if err := cli.Delete(context.TODO(), &secret); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func PurgeAllNodes(cli client.Client, opts ...client.ListOption) error {
-	var nodes corev1.NodeList
-	err := cli.List(context.TODO(), &nodes)
-	if err != nil {
-		return err
-	}
-
-	for _, secret := range nodes.Items {
-		if err := cli.Delete(context.TODO(), &secret); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/pkg/util/test/purge.go
+++ b/pkg/util/test/purge.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apis "github.com/FabEdge/fab-dns/pkg/apis/v1alpha1"
@@ -38,6 +39,15 @@ func PurgeAllServices(cli client.Client, opts ...client.ListOption) {
 	Expect(cli.List(context.TODO(), &services)).To(Succeed())
 
 	for _, obj := range services.Items {
+		Expect(cli.Delete(context.TODO(), &obj)).To(Succeed())
+	}
+}
+
+func PurgeAllEndpointSlices(cli client.Client, opts ...client.ListOption) {
+	var endpointslices discoveryv1.EndpointSliceList
+	Expect(cli.List(context.TODO(), &endpointslices)).To(Succeed())
+
+	for _, obj := range endpointslices.Items {
 		Expect(cli.Delete(context.TODO(), &obj)).To(Succeed())
 	}
 }


### PR DESCRIPTION
Sometimes a cluster won's has the namespace under which some global services will be created, so it's necessary to allow service-hub to create namespace when it does not exist.